### PR TITLE
Identifies the global runtime vs subcommand runtime distinction.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,26 @@
 Jinx: a jinkies coordination tool
 
-Usage:
 
-jinkies serve start - starts a jinkies on localhost 😯
-jinkies serve start -o hostconfig.yml - the `-o` flag allows the end user to specify any of the docker engine [https://pkg.go.dev/github.com/docker/docker@v20.10.12+incompatible/api/types/container#HostConfig] hostconfig options  😯
-jinkies serve start -c containerconfig.yml - the `-c` flag allows the end user to specify any of the docker engine [https://pkg.go.dev/github.com/docker/docker@v20.10.12+incompatible/api/types/container#Config] containerconfig options  😯
+Usage:
+## Global default file
+On startup, jinx defaults to assuming the container can be called `jinkies` and that you _do_ want to pull the latest
+version of images from docker hub. This container can be tweaked:
+- If a file named `jinx.yml` exists in the pwd of the calling process, it is read in and overrides the default configuration.
+- If the `-j` option is supplied like `-j path/to/globalconfig.yml`, then this file is used for the global config. 
+
+The options it controls are documented in examples/jinx.yml.
+
+jinx -j path/to/jinx.yml - 
+
+## `jinx serve`
+`jinx serve start` - starts a jinkies on localhost 😯
+`jinx serve stop`  - stops the jinkies on localhost
+
+The `start`  subcommand further exposes all of the options that docker engine allows you to configure via two configuration
+files, called the host config file and the container config file.
+
+jinx serve start -o hostconfig.yml - the `-o` flag allows the end user to specify any of the docker engine [https://pkg.go.dev/github.com/docker/docker@v20.10.12+incompatible/api/types/container#HostConfig] hostconfig options
+jinx serve start -c containerconfig.yml - the `-c` flag allows the end user to specify any of the docker engine [https://pkg.go.dev/github.com/docker/docker@v20.10.12+incompatible/api/types/container#Config] containerconfig options
 
 Examples of how these yml files are structured are in the examples/ directory.
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,9 @@ Copyright © 2022 NAME HERE <EMAIL ADDRESS>
 package cmd
 
 import (
+	"fmt"
+	"jinx/src/utils"
+	jinxtypes "jinx/types"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -30,14 +33,39 @@ func Execute() {
 	}
 }
 
-func init() {
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
+//Sets up the global configuration struct by first setting the runtime to our known sane defaults,
+//then checking to see whether the user supplies a config file option on the command line. If so,
+//overwrite the global configuration struct with the config file contents.
+//Also checks for the default jinx.yml config file. If it exists in the same directory as the calling process,
+//it is used.
+func SetupGlobalConfig() jinxtypes.JinxData {
+	configFilePath := "jinx.yml"
+	configFileDefault := ""
+	configFileOption := configFileDefault
 
-	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.tmp.yaml)")
+	JinxRuntime := jinxtypes.JinxData{PullImages: true, ContainerName: "jinkies"}
 
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
-	//rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	serveCmd.PersistentFlags().StringVarP(&configFileOption, "jinxconfig", "j", configFileOption, "Path to config file for jinx global options")
+
+	//Check if the option flag was passed in and read its value if need be to override the default.
+	configOptionPassedIn := configFileOption != configFileDefault
+
+	if configOptionPassedIn {
+		configFilePath = configFileOption
+	}
+
+	if _, err := os.Open(configFilePath); err == nil {
+		utils.HydrateFromConfig(configFilePath, &JinxRuntime)
+	}
+
+	if configOptionPassedIn {
+		//The end user asked us to verify the existence of a file by giving us the explicit expectation
+		//that this filename exists. The file not existing is an error.
+		fmt.Fprintf(os.Stderr, "%v does not exist", configFilePath)
+	} else {
+		//The jinx.yaml file does not exist, but we only checked as a convenience for the user.
+		//We can safely proceed with the default Jinx Runtime.
+	}
+
+	return JinxRuntime
 }

--- a/examples/jinx.yml
+++ b/examples/jinx.yml
@@ -1,3 +1,12 @@
 ---
+//This file is consumed by the `-j` cli option.
+
+//ContainerName: The name of a container for commands to operate on. Note that jinx does not internally track container
+//  container names, so if your config file `somefile.yml` contains a custom container name and you run 
+//  `jinx serve start -j somefile.yml`, then when you run `jinx serve stop` you should also supply `-j somefile.yml` 
+//  so that the stop command stops the right container.
 ContainerName: "jinkies"
+//PullImages: true - jinx will reach out to docker hub to download the image you're operating on.
+//PullImages: false - jinx will not reach out to docker hub. This is primarily for when you are developing an image and
+//  want to use jinx with that image, but is appropriate for any situation where you do not want to download images.
 PullImages: false

--- a/main.go
+++ b/main.go
@@ -4,8 +4,13 @@ Copyright © 2022 NAME HERE <EMAIL ADDRESS>
 */
 package main
 
-import "jinx/cmd"
+import (
+	"jinx/cmd"
+)
 
 func main() {
+	jinxRuntime := cmd.SetupGlobalConfig()
+
+	cmd.RegisterServe(jinxRuntime)
 	cmd.Execute()
 }

--- a/types/jinxData.go
+++ b/types/jinxData.go
@@ -1,0 +1,10 @@
+package jinxtypes
+
+//Global jinx cli options useful across multiple commands.
+//ContainerName the name of a container that the current command should operate against.
+//PullImages should an image be pulled, or not? If not, we are going to assume the image already
+//exists in the current docker image cache.
+type JinxData struct {
+	ContainerName string
+	PullImages    bool
+}


### PR DESCRIPTION
This involved writing a type for the global runtime that can be
retrieved in main and passed in to subcommands.

There's now logic in the root command to appropriately consume
the global runtime config file, also.

[x] Have you updated any appropriate docs
[x] Are comments up to date
[x] Did you run `go fmt`
